### PR TITLE
fix: Default for Output should be empty

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,7 +9,7 @@ const { argv } = yargs
   })
   .option("output", {
     type: "string",
-    default: process.cwd(),
+    default: "",
     description: "Output directory",
   })
   .option("quality", {


### PR DESCRIPTION
The default for output should be empty, so when no output is set then outdir = inputdir.

Otherwise this condition (convert.js) only has effect if output is manually set to empty via cmd (output=""):
```js
  const outputPath = path.join(
    output ? output : path.dirname(input),
    outputFilename
  );
```