### PR TITLE
Add flag to append new file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Exit code is non-zero if one or more errors occured.
                                                      [string] [default: "4:4:4"]
       --overwrite          Allow existing output files to be overwritten
                                                       [boolean] [default: false]
+      --append-ext         Add .avif to the file name, instead of replacing the
+                           existing extension (foo.jpg => foo.jpg.avif)
+                                                      [boolean] [default: false]
       --verbose            Write progress to stdout   [boolean] [default: false]
   -h, --help               Show help                                   [boolean]
       --version            Show version number                         [boolean]

--- a/bin/avif.js
+++ b/bin/avif.js
@@ -8,6 +8,7 @@ const {
   speed,
   chromaSubsampling,
   overwrite,
+  appendExt,
   verbose,
 } = require("../lib/cli");
 const glob = require("../lib/glob");
@@ -28,6 +29,7 @@ const avif = async () => {
         speed,
         chromaSubsampling,
         overwrite,
+        appendExt,
         verbose,
       })
     )

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -42,7 +42,8 @@ const { argv } = yargs
   .option("appendExt", {
     type: "boolean",
     default: false,
-    description: "Append .avif to the file name instead of replacing the current extension",
+    description:
+      "Append .avif to the file name instead of replacing the current extension",
   })
   .option("verbose", {
     type: "boolean",

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -43,7 +43,7 @@ const { argv } = yargs
     type: "boolean",
     default: false,
     description:
-      "Append .avif to the file name instead of replacing the current extension",
+      "Append .avif to the file name instead of replacing the current extension (foo.jpg => foo.jpg.avif)",
   })
   .option("verbose", {
     type: "boolean",

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -39,6 +39,11 @@ const { argv } = yargs
     default: false,
     description: "Allow existing output files to be overwritten",
   })
+  .option("appendExt", {
+    type: "boolean",
+    default: false,
+    description: "Append .avif to the file name instead of replacing the current extension",
+  })
   .option("verbose", {
     type: "boolean",
     default: false,

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -10,11 +10,15 @@ module.exports = async ({
   speed,
   chromaSubsampling,
   overwrite,
+  appendExt,
   verbose,
 }) => {
-  const outputFilename = path
-    .basename(input)
-    .replace(path.extname(input), ".avif");
+  let outputFilename = path.basename(input);
+  if (appendExt) {
+    outputFilename = outputFilename + ".avif";
+  } else {
+    outputFilename = outputFilename.replace(path.extname(input), ".avif");
+  }
   const outputPath = path.join(
     output ? output : path.dirname(input),
     outputFilename


### PR DESCRIPTION
Having an option to append .avif is useful so nginx try_files usage [stays simple](https://vincent.bernat.ch/en/blog/2021-webp-avif-nginx).

Without the flag `foo.jpg` => `foo.avif`
With the flag `--append-ext` `foo.jpg` => `foo.jpg.avif`

This implements the footnote on #8 