### PR TITLE
Create output directory if not exist

### DIFF
--- a/bin/avif.js
+++ b/bin/avif.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+const fs = require("fs").promises;
+const { constants } = require("fs");
 const {
   input,
   output,
@@ -18,6 +20,13 @@ const avif = async () => {
   const files = await glob(input);
   if (verbose) {
     process.stdout.write(`Found ${files.length} file(s) matching ${input}\n`);
+  }
+  if (output) {
+    try {
+        await fs.access(output, constants.W_OK);
+    } catch (e) {
+        await fs.mkdir(output, { recursive: true });
+    }
   }
   const results = await Promise.all(
     files.map((file) =>


### PR DESCRIPTION
This prevents the following error if the user doesn't create the output directory beforehand:

```
$ npx avif --input '*.jpg' --output out
~/1.jpg: out/1.avif: unable to open for write
out/2.avif: unable to open for write
unix error: No such file or directory
unix error: No such file or directory

~/2.jpg: out/1.avif: unable to open for write
out/2.avif: unable to open for write
unix error: No such file or directory
unix error: No such file or directory
```