### PR TITLE
Feature/recursive

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,14 +4,23 @@ const { argv } = yargs
   .usage("Convert images to AVIF")
   .option("input", {
     type: "string",
-    default: "*.{jpg,jpeg,tif,tiff,webp,png,gif,svg}",
-    description: "Input file name(s), supports globs/wildcards",
+    default: process.cwd().replace(/\\/g, "/"),
+    description:
+      "Input directory, Default is the absolute path to the directory that invoked this.",
+  })
+  .alias("i", "input")
+  .option("target", {
+    type: "string",
+    default: "jpg,jpeg,tif,tiff,webp,png,gif,svg",
+    description:
+      "Extensions of the file to be converted. Separated by commas without spaces",
   })
   .option("output", {
     type: "string",
     default: "",
     description: "Output directory, default is same directory as input",
   })
+  .alias("o", "output")
   .option("quality", {
     type: "number",
     default: 50,
@@ -56,8 +65,15 @@ const { argv } = yargs
     default: false,
     description: "Write progress to stdout",
   })
+  .option("recursive", {
+    type: "boolean",
+    default: false,
+    description: "Converts the contents of all subfiles to the same structure.", // Process subdirectories recursively
+  })
+  .alias("r", "recursive") // Alias for recursive option
   .help("h")
   .alias("h", "help")
-  .version();
+  .version()
+  .alias("v", "version");
 
 module.exports = argv;

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -20,12 +20,12 @@ module.exports = async ({
   } else {
     outputFilename = outputFilename.replace(path.extname(input), ".avif");
   }
-  const outputPath = path.join(
-    output ? output : path.dirname(input),
-    outputFilename,
-  );
+  const outputPath = output
+    ? path.join(output, outputFilename) // Use adjusted output path for recursive mode
+    : path.join(path.dirname(input), outputFilename);
 
   try {
+    await fs.mkdir(path.dirname(outputPath), { recursive: true }); // Ensure output directory exists
     const exists = (await fs.stat(outputPath)).isFile();
     if (exists && !overwrite) {
       if (verbose) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "avif"
   ],
   "dependencies": {
+    "avif": "file:",
     "sharp": "^0.33.5",
     "tinyglobby": "^0.2.6",
     "yargs": "^17.7.2"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "avif"
   ],
   "dependencies": {
-    "avif": "file:",
     "sharp": "^0.33.5",
     "tinyglobby": "^0.2.6",
     "yargs": "^17.7.2"


### PR DESCRIPTION
With the traditional glob method of taking input, we could use wildcards to specify that files in subfolders should be converted together, but the output folder would store all the files together without any existing file structure distinction. This was not only a pain in the ass, but also caused the conversion to be missed if files with the same name were found in different folders, so I added the `--recursive` option.

To make it easier to understand the relative paths of the input and target files, I wanted to limit `--input` to specifying the target folder and separate the option to specify an extension into `--target`. However, it is still possible to utilize traditional wildcards. In the long run, I would suggest limiting or separating the functionality completely.

This pull request includes significant updates to the `lib/cli.js` and `lib/convert.js` files to enhance the functionality and usability of the image conversion tool. The most important changes include adding new options for specifying input and output directories, handling recursive directory processing, and ensuring output directories exist before writing files. Additionally, a minor dependency update was made in `package.json`.

Enhancements to command-line options:

* [`lib/cli.js`](diffhunk://#diff-347ff93ed2b00c93c817863e32fbac5b4fac71d7339a48378980e682777689f4L7-R23): Changed the `input` option to accept an input directory and added a `target` option to specify file extensions for conversion.
* [`lib/cli.js`](diffhunk://#diff-347ff93ed2b00c93c817863e32fbac5b4fac71d7339a48378980e682777689f4R68-R77): Added a `recursive` option to process subdirectories recursively and provided aliases for the new options.

Improvements to file handling:

* [`lib/convert.js`](diffhunk://#diff-51ac93c50822b9502a1ba7f668d8de0028ea9ac00873cda9335ce6e2dadea5d6L23-R28): Adjusted the output path handling to support recursive mode and ensured the output directory exists before writing files.
